### PR TITLE
Legend fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggExtra
 Title: Add Marginal Histograms to 'ggplot2', and More 'ggplot2' Enhancements
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(
     person("Dean", "Attali", , "daattali@gmail.com", role = c("aut", "cre"))
     )
@@ -14,7 +14,7 @@ Depends:
 Imports:
     ggplot2 (>= 1.0.0),
     grid (>= 3.1.3),
-    gridExtra (>= 0.9.1),
+    gridExtra (>= 2.2.1),
     methods,
     miniUI (>= 0.1.1),
     shiny (>= 0.11.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ggExtra 0.4.1
+
+2016-04-24
+
+- Remove hack required by old version of `gridExtra`
+
 # ggExtra 0.4.0
 
 2016-03-25

--- a/R/ggMarginal.R
+++ b/R/ggMarginal.R
@@ -125,6 +125,7 @@ ggMarginal <- function(p, data, x, y, type = c("density", "histogram", "boxplot"
       }
       data <- p$data
     }
+    if (length(p$mapping) == 0) p$mapping <- p$layers[[1]]$mapping
     if (margins != "y" && missing(x)) {
       if (is.null(p$mapping$x)) {
         stop("`x` must be provided if it is not an aesthetic of the main ggplot object",

--- a/R/ggMarginal.R
+++ b/R/ggMarginal.R
@@ -446,17 +446,7 @@ ggMarginal <- function(p, data, x, y, type = c("density", "histogram", "boxplot"
                 widths = list(grid::unit(c(size, colSize), "null")),
                 heights = list(grid::unit(c(titleSize, rowSize, size), "null"))
               )
-  
-  # NOTE: This ugly hack is here because of a bug in gridExtra which calls
-  # a ggplot2 function directly instead of namespacing it.  The bug is fixed
-  # in the gridExtra GitHub version, but not on CRAN. Hopefully gridExtra
-  # will submit the fix to CRAN and I can remove this ugliness.
-  # https://github.com/baptiste/gridextra/issues/5
-  if (!"package:ggplot2" %in% search()) {
-    suppressPackageStartupMessages(attachNamespace("ggplot2"))
-    on.exit(detach("package:ggplot2"))
-  }
-  
+
   # NOTE: I had to use arrangeGrob instead of grid.arrange because the latter does
   # not allow saving the object, it only works as a side-effect and returns NULL.
   # There were still problems with arrangeGrob - if gridExtra isn't loaded, I

--- a/R/ggMarginal.R
+++ b/R/ggMarginal.R
@@ -148,8 +148,14 @@ ggMarginal <- function(p, data, x, y, type = c("density", "histogram", "boxplot"
   
   # Remove all margin around plot so that it's easier to position the
   # density plots beside the main plot
-  p <- p + ggplot2::theme(plot.margin = grid::unit(c(0, 0, 0, 0), "null"))
-
+  p <- p + ggplot2::theme(plot.margin = grid::unit(c(0, 0, 0, 0), "null"),
+                          legend.direction = "horizontal")
+  # Grab the legend grob if there is one, then reset theme to show no legend
+  tabpb <- ggplot2::ggplot_gtable(ggplot2::ggplot_build(p))
+  lgnd_ind <- which(sapply(tabpb$grobs, function(x) x$name) == "guide-box")
+  if (length(lgnd_ind) != 0) tabpb$grobs[[lgnd_ind]] -> lgnd_grob
+  p <- p + ggplot2::theme(legend.position = "none")
+  
   # Decompose the original ggplot2 object to grab all sorts of information from it
   pb <- ggplot2::ggplot_build(p)
 
@@ -430,7 +436,6 @@ ggMarginal <- function(p, data, x, y, type = c("density", "histogram", "boxplot"
     titleSize <- 0
   }
   
-  
   if (margins == "both") {
     plots <- list(title, empty, top, empty, p, right)
   } else if (margins == "x") {
@@ -441,11 +446,15 @@ ggMarginal <- function(p, data, x, y, type = c("density", "histogram", "boxplot"
     rowSize <- 0
   }
   
+  if (exists("lgnd_grob")) {
+      nrow <- 4
+      plots <- c(plots, list(lgnd_grob, empty))
+  }
   # Determine all the arguments to build the grid (dimensions, plots, plot sizes)
   gridArgs <- c(plots, ncol = ncol, nrow = nrow)
   gridArgs <- c(gridArgs,
                 widths = list(grid::unit(c(size, colSize), "null")),
-                heights = list(grid::unit(c(titleSize, rowSize, size), "null"))
+                heights = list(grid::unit(c(titleSize, rowSize, size, size/5), "null"))
               )
 
   # NOTE: I had to use arrangeGrob instead of grid.arrange because the latter does

--- a/R/ggMarginal.R
+++ b/R/ggMarginal.R
@@ -449,12 +449,15 @@ ggMarginal <- function(p, data, x, y, type = c("density", "histogram", "boxplot"
   if (exists("lgnd_grob")) {
       nrow <- 4
       plots <- c(plots, list(lgnd_grob, empty))
+      c(titleSize, rowSize, size, size/5) -> z
+  } else {
+      c(titleSize, rowSize, size) -> z
   }
   # Determine all the arguments to build the grid (dimensions, plots, plot sizes)
   gridArgs <- c(plots, ncol = ncol, nrow = nrow)
   gridArgs <- c(gridArgs,
                 widths = list(grid::unit(c(size, colSize), "null")),
-                heights = list(grid::unit(c(titleSize, rowSize, size, size/5), "null"))
+                heights = list(grid::unit(z, "null"))
               )
 
   # NOTE: I had to use arrangeGrob instead of grid.arrange because the latter does

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This is an instructional document, but I also wrote [a blog
 post](http://deanattali.com/2015/03/29/ggExtra-r-package/) about the
 reasoning behind and development of this package.
 
+Note: it was brought to my attention that several years ago there was a
+different package called `ggExtra`, by Baptiste (the author of
+`gridExtra`). That old `ggExtra` package was deleted in 2011 (two years
+before I even knew what R is!), and this package has nothing to do with
+the old one.
+
 Installation
 ------------
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -374,3 +374,20 @@ addressed previous comment: changed URL of CRAN package to canonical form
 2015-11-06 Kurt Hornik
 
 Thanks, on CRAN now
+
+# Version 0.4.0
+
+# Round 1
+
+## Test environments
+
+* local Windows 7, R 3.2.4
+* ubuntu 12.04 (on travis-ci), R 3.2.4
+
+## Submission comments:
+
+2016-03-27
+
+Tested on Windows 7 and ubuntu 14.04; no errors, warnings, or notes. Submitting updated version in response to Hadley's testthat upcoming update
+
+## Reviewer comments

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -391,3 +391,7 @@ Thanks, on CRAN now
 Tested on Windows 7 and ubuntu 14.04; no errors, warnings, or notes. Submitting updated version in response to Hadley's testthat upcoming update
 
 ## Reviewer comments
+
+2016-03-28 Kurt Hornik
+
+Thanks, on CRAN now

--- a/vignettes/overview.Rmd
+++ b/vignettes/overview.Rmd
@@ -31,6 +31,8 @@ Most other functions/layers are quite simple but are useful because they are fai
 This is an instructional document, but I also wrote [a blog post](http://deanattali.com/2015/03/29/ggExtra-r-package/) about the reasoning
 behind and development of this package.
 
+Note: it was brought to my attention that several years ago there was a different package called `ggExtra`, by Baptiste (the author of `gridExtra`). That old `ggExtra` package was deleted in 2011 (two years before I even knew what R is!), and this package has nothing to do with the old one. 
+
 ## Installation
 
 `ggExtra` is available through both CRAN and GitHub.


### PR DESCRIPTION
* You might want to add a param for the legend size relative to the scatter plot size.
* I'm pretty sure `legend.position = "none"` is the syntax used in old versions of ggplot2. Do you happen to know off hand? If it isn't, then then the fix may not work for some users.
* Sry about all the erroneous commits. Still trying to figure GitHub out...