### PR TITLE
add grouping feature tests to test suite (closes #96)

### DIFF
--- a/tests/testthat/test-ggMarginal.R
+++ b/tests/testthat/test-ggMarginal.R
@@ -22,6 +22,17 @@ runMarginalTests <- function(ggplot2Version) {
              "scale transformations work"), function(x)
                expectDopp2(funName = x, ggplot2Version = ggplot2Version))
   })
+  
+  test_that("Grouping feature works as expected" , {
+    sapply(
+      c(
+        "col and fill mapped", "fill mapped with low alpha",
+        "colour mapped with grey fill",
+        "colour mapped and colour param provided",
+        "colour & fill mapped and both params provided"
+      ), function(x) expectDopp2(funName = x, ggplot2Version = ggplot2Version)
+    )
+  })
 
 }
 


### PR DESCRIPTION
I will reformat the other `test_that` function calls so all their styles are consistent when closing #87 