### PR TITLE
Feature: Add marginal for data that is different from plot data

### DIFF
--- a/R/ggMarginal-helpers-genFinalMargPlot.R
+++ b/R/ggMarginal-helpers-genFinalMargPlot.R
@@ -1,9 +1,11 @@
 # Main helper in ggMarginal to create marginal plots ---------------------------
 
 # Wrapper function to create a "final" marginal plot
-genFinalMargPlot <- function(marg, type, scatPbuilt, prmL, groupColour,
+genFinalMargPlot <- function(data, varname,
+                             marg, type, scatPbuilt, prmL, groupColour,
                              groupFill) {
   rawMarg <- genRawMargPlot(
+    data = data, varname,
     marg, type = type, scatPbuilt = scatPbuilt, prmL = prmL,
     groupColour = groupColour, groupFill = groupFill
   )
@@ -26,9 +28,26 @@ genFinalMargPlot <- function(marg, type, scatPbuilt, prmL, groupColour,
 }
 
 # Function to create a "raw" marginal plot
-genRawMargPlot <- function(marg, type, scatPbuilt, prmL, groupColour,
+genRawMargPlot <- function(data, varname,
+                           marg, type, scatPbuilt, prmL, groupColour,
                            groupFill) {
-  data <- getVarDf(marg = marg, scatPbuilt = scatPbuilt)
+  if (missing(data)) {
+    data <- getVarDf(marg = marg, scatPbuilt = scatPbuilt)
+  } else {
+    if (missing(varname)) {
+      varname <- as.character(scatPbuilt$plot$mapping[[marg]])
+    }
+    # data <- subset(data, select = varname)
+    # data$fill <- NA
+    # data$colour <- "black"
+    # data$group <- -1L
+    data <- data.frame(
+      var = data[[varname]],
+      fill <- NA,
+      colour <- "black",
+      group <- -1L,
+      stringsAsFactors = FALSE)
+  }
 
   noGeomPlot <- margPlotNoGeom(
     data, type = type, scatPbuilt = scatPbuilt, 

--- a/R/ggMarginal-helpers-genFinalMargPlot.R
+++ b/R/ggMarginal-helpers-genFinalMargPlot.R
@@ -37,7 +37,11 @@ genRawMargPlot <- function(data, varname,
     if (missing(varname)) {
       varname <- as.character(scatPbuilt$plot$mapping[[marg]])
     }
-    # data <- subset(data, select = varname)
+    if (is.null(varname) || ! varname %in% names(data)) {
+      stop("Could not identify column corresponding to ", marg,
+           " in data.  I tried \"", format(varname), "\").")
+    }
+      # data <- subset(data, select = varname)
     # data$fill <- NA
     # data$colour <- "black"
     # data$group <- -1L

--- a/R/ggMarginal.R
+++ b/R/ggMarginal.R
@@ -145,6 +145,7 @@ ggMarginal <- function(p, data, x, y, type = c("density", "histogram", "boxplot"
   # Top plot = horizontal margin plot, which corresponds to x marg
   if (margins != "y") {
     top <- genFinalMargPlot(
+      data = data, varname = x,
       marg = "x", type = type, scatPbuilt = scatPbuilt, prmL = prmL,
       groupColour = groupColour, groupFill = groupFill
     )
@@ -154,6 +155,7 @@ ggMarginal <- function(p, data, x, y, type = c("density", "histogram", "boxplot"
   # (right plot = vertical margin plot, which corresponds to y marg)
   if (margins != "x") {
     right <- genFinalMargPlot(
+      data = data, varname = y,
       marg = "y", type = type, scatPbuilt = scatPbuilt, prmL = prmL,
       groupColour = groupColour, groupFill = groupFill
     )


### PR DESCRIPTION
I had the following use case: I plot prediction data from a model (glm or gam).  The predicted data is generated using a uniform x-range (i.e. something like `seq(min(x), max(x), 0.01`).  Now I want to add to this plot the marginal distribution of the data underlying the prediction, which is not uniformly distributed on the x-range.

The documentation to the function `ggMarginal` seemed to suggest to me that this should be possible: "`data` is optional if `p` is provided".  The truth is rather that `data` is ignored if `p` is provided.  So I tried to improve this.  In my fork, `data` is used to generate the marginal distribution.

Please test!