### PR TITLE
Refactor tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,3 @@ before_install:
 script:
   - rm -rf ggExtra.Rcheck
   - travis_wait 40 docker run -v `pwd`/ggExtra.Rcheck:/home/ggExtra/ggExtra.Rcheck ggextra-image /bin/bash -c 'R CMD build ../ggExtra && R CMD check ggExtra_* --as-cran --no-manual'
-
-after_failure:
-  - cat ggExtra.Rcheck/tests/testthat.Rout

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ before_install:
 script:
   - rm -rf ggExtra.Rcheck
   - travis_wait 40 docker run -v `pwd`/ggExtra.Rcheck:/home/ggExtra/ggExtra.Rcheck ggextra-image /bin/bash -c 'R CMD build ../ggExtra && R CMD check ggExtra_* --as-cran --no-manual'
+
+after_failure:	
+  - cat ggExtra.Rcheck/tests/testthat.Rout.fail

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
 
 script:
   - rm -rf ggExtra.Rcheck
-  - docker run -v `pwd`/ggExtra.Rcheck:/home/ggExtra/ggExtra.Rcheck ggextra-image /bin/bash -c 'R CMD build ../ggExtra && R CMD check ggExtra_* --as-cran --no-manual'
+  - travis_wait 40 docker run -v `pwd`/ggExtra.Rcheck:/home/ggExtra/ggExtra.Rcheck ggextra-image /bin/bash -c 'R CMD build ../ggExtra && R CMD check ggExtra_* --as-cran --no-manual'
 
 after_failure:
   - cat ggExtra.Rcheck/tests/testthat.Rout

--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,5 @@ render-figs:
 		Rscript -e "devtools::load_all(); source('tests/testthat/render-figs.R')"
 
 test:
-	docker run ggextra-image /bin/bash -c 'R CMD build ../ggExtra && R CMD check ggExtra_* --as-cran --no-manual'
+	docker run --rm -v `pwd`:/home/ggExtra ggextra-image \
+		/bin/bash -c 'R CMD build ../ggExtra && R CMD check ggExtra_* --as-cran --no-manual'

--- a/tests/testthat/helper-funs.R
+++ b/tests/testthat/helper-funs.R
@@ -17,80 +17,95 @@ basicScatPWithLims <- function() {
   basicScatP() + ggplot2::scale_x_continuous(limits = c(0, 2))
 }
 
-funList <-
-  list(
-    "basic density" = function() ggMarg2("density"),
-    "basic histogram" = function() ggMarg2("histogram"),
-    "basic boxplot" = function() ggMarg2("boxplot"),
-    "basic violin plot" = function() ggMarg2("violin"),
-    "basic densigram" = function() ggMarg2("densigram"),
-    "scatter plot from data" = function() ggMarginal(
-      data = mtcars, x = "mpg", y = "disp", type = "density"
-    ),
-    "only x margin" = function() ggMarg2("density", margins = "x"),
-    "smaller marginal plots" = function() ggMarg2("density", size = 10),
-    "both hists red col" = function() ggMarg2("histogram", colour = "red"),
-    "top hist red col and fill" = function() ggMarg2(
-      "histogram", xparams = list(colour = "red", fill = "red")
-    ),
-    "theme bw" = function() ggMarginal(
-      basicScatP() + ggplot2::theme_bw(), type = "density"
-    ),
-    "legend and title" = function() ggMarginal(
-      ggplot2::ggplot(mtcars) +
-        ggplot2::geom_point(ggplot2::aes(x = wt, y = drat, colour = gear)) +
-        ggplot2::ggtitle("pretty sweet title", "not a bad subtitle either") +
-        ggplot2::theme(plot.title = ggplot2::element_text(colour = "red"))
-    ),
-    "flipped coord where x is drat and y is wt" = function() ggMarginal(
-      basicScatP() + ggplot2::coord_flip(), type = "density"
-    ),
-    "col and fill mapped" = function() ggMarginal(
-      margMapP(), groupColour = TRUE, groupFill = TRUE
-    ),
-    "fill mapped with low alpha" = function() ggMarginal(
-      margMapP(), groupFill = TRUE, alpha = .2
-    ),
-    "colour mapped with grey fill" = function() ggMarginal(
-      p = margMapP(), groupColour = TRUE, fill = "grey"
-    ),
-    "colour mapped and colour param provided" = function() ggMarginal(
-      margMapP(), groupColour = TRUE, colour = "red"
-    ),
-    "colour & fill mapped and both params provided" = function() ggMarginal(
-      margMapP(), groupColour = TRUE, groupFill = TRUE, 
-      colour = "red", fill = "blue"
-    ),
-    "subtitle but no title" = function() ggMarginal(
-      basicScatP() + ggplot2::labs(subtitle = "This should be above marginal")
-    ),
-    "x-axis limits using scale_x_continuous" = function() ggMarginal(
-      basicScatPWithLims()
-    ),
-    "axis limits using xlim and ylim" = function() ggMarginal(
-      basicScatP() + ggplot2::xlim(2, 5) + ggplot2::ylim(3, 4.5)
-    ),
-    "x-axis limits for histograms" = function() ggMarginal(
-      basicScatPWithLims(), type = "histogram"
-    ),
-    "x-axis limits for marginals with y aes" = function() ggMarginal(
-      basicScatPWithLims(), type = "violin"
-    ),
-    "x and y scale_reverse" = function() ggMarginal(
-      basicScatP() + ggplot2::scale_x_reverse() + ggplot2::scale_y_reverse()
-    ),
-    "geom_smooth with aligned marg plots" = function() ggMarginal(
-      basicScatP() + ggplot2::geom_smooth(), type = "histogram"
-    ),
-    "geom_line provided as first geom" = function() ggMarginal(
-      ggplot2::ggplot(mtcars, ggplot2::aes(x = wt, y = mpg)) + 
-        ggplot2::geom_line() + 
-        ggplot2::geom_point()
-    ),
-    "no density fill for densigrams" = function() ggMarginal(
-      basicScatP(), type = "densigram", fill = "blue"
-    )
+basic_marginals <- list(
+  "basic density" = function() ggMarg2("density"),
+  "basic histogram" = function() ggMarg2("histogram"),
+  "basic boxplot" = function() ggMarg2("boxplot"),
+  "basic violin plot" = function() ggMarg2("violin"),
+  "basic densigram" = function() ggMarg2("densigram"),
+  "scatter plot from data" = function() ggMarginal(
+    data = mtcars, x = "mpg", y = "disp", type = "density"
   )
+)
+other_params <- list(
+  "only x margin" = function() ggMarg2("density", margins = "x"),
+  "smaller marginal plots" = function() ggMarg2("density", size = 10),
+  "both hists red col" = function() ggMarg2("histogram", colour = "red"),
+  "top hist red col and fill" = function() ggMarg2(
+    "histogram", xparams = list(colour = "red", fill = "red")
+  )
+)
+misc_issues <- list(
+  "theme bw" = function() ggMarginal(
+    basicScatP() + ggplot2::theme_bw(), type = "density"
+  ),
+  "legend and title" = function() ggMarginal(
+    ggplot2::ggplot(mtcars) +
+      ggplot2::geom_point(ggplot2::aes(x = wt, y = drat, colour = gear)) +
+      ggplot2::ggtitle("pretty sweet title", "not a bad subtitle either") +
+      ggplot2::theme(plot.title = ggplot2::element_text(colour = "red"))
+  ),
+  "flipped coord where x is drat and y is wt" = function() ggMarginal(
+    basicScatP() + ggplot2::coord_flip(), type = "density"
+  ),
+  "subtitle but no title" = function() ggMarginal(
+    basicScatP() + ggplot2::labs(subtitle = "This should be above marginal")
+  ),
+  "geom_line provided as first geom" = function() ggMarginal(
+    ggplot2::ggplot(mtcars, ggplot2::aes(x = wt, y = mpg)) + 
+      ggplot2::geom_line() + 
+      ggplot2::geom_point()
+  ),
+  "no density fill for densigrams" = function() ggMarginal(
+    basicScatP(), type = "densigram", fill = "blue"
+  )
+)
+grouping_feature <- list(
+  "col and fill mapped" = function() ggMarginal(
+    margMapP(), groupColour = TRUE, groupFill = TRUE
+  ),
+  "fill mapped with low alpha" = function() ggMarginal(
+    margMapP(), groupFill = TRUE, alpha = .2
+  ),
+  "colour mapped with grey fill" = function() ggMarginal(
+    p = margMapP(), groupColour = TRUE, fill = "grey"
+  ),
+  "colour mapped and colour param provided" = function() ggMarginal(
+    margMapP(), groupColour = TRUE, colour = "red"
+  ),
+  "colour & fill mapped and both params provided" = function() ggMarginal(
+    margMapP(), groupColour = TRUE, groupFill = TRUE, 
+    colour = "red", fill = "blue"
+  )
+)
+transforms <- list(
+  "x-axis limits using scale_x_continuous" = function() ggMarginal(
+    basicScatPWithLims()
+  ),
+  "axis limits using xlim and ylim" = function() ggMarginal(
+    basicScatP() + ggplot2::xlim(2, 5) + ggplot2::ylim(3, 4.5)
+  ),
+  "x-axis limits for histograms" = function() ggMarginal(
+    basicScatPWithLims(), type = "histogram"
+  ),
+  "x-axis limits for marginals with y aes" = function() ggMarginal(
+    basicScatPWithLims(), type = "violin"
+  ),
+  "x and y scale_reverse" = function() ggMarginal(
+    basicScatP() + ggplot2::scale_x_reverse() + ggplot2::scale_y_reverse()
+  ),
+  "geom_smooth with aligned marg plots" = function() ggMarginal(
+    basicScatP() + ggplot2::geom_smooth(), type = "histogram"
+  )
+)
+
+funList <- list(
+  basic_marginals = basic_marginals,
+  other_params = other_params,
+  misc_issues = misc_issues,
+  grouping_feature = grouping_feature,
+  transforms = transforms
+)
 
 expectDopp2 <- function(funName, ggplot2Version) {
 

--- a/tests/testthat/helper-funs.R
+++ b/tests/testthat/helper-funs.R
@@ -176,19 +176,11 @@ attemptRepoDate <- function(package, version) {
   sprintf("https://mran.microsoft.com/snapshot/%s", dateString)
 }
 
-## By default, do not run the tests (which also means do not run on CRAN)
+# RunGgplot2Tests is set to "yes" in dockerfile, which means shouldTest()
+# will return TRUE only when it's run inside a docker container (i.e., it will 
+# return FALSE on CRAN).
 shouldTest <- function() {
-  if (
-    ## Use the Travis / GitHub integrations as we set this environment variable
-    ## to "yes" in .travis.yml
-    Sys.getenv("RunGgplot2Tests") == "yes" ||
-      ## Also run the tests when building on Dean or Chris' machine
-      Sys.info()["user"] %in% c("cbaker", "Dean")
-  ) {
-    TRUE
-  } else {
-    FALSE
-  }
+  Sys.getenv("RunGgplot2Tests") == "yes"
 }
 
 # Misc function to drop muffle a particular warning that occurs whenever a

--- a/tests/testthat/helper-funs.R
+++ b/tests/testthat/helper-funs.R
@@ -1,3 +1,5 @@
+# Wrappers around ggMarginal and ggplot function calls ------------------------
+
 basicScatP <- function() {
   ggplot2::ggplot(mtcars, ggplot2::aes(x = wt, y = drat)) +
     ggplot2::geom_point()
@@ -16,6 +18,8 @@ margMapP <- function() {
 basicScatPWithLims <- function() {
   basicScatP() + ggplot2::scale_x_continuous(limits = c(0, 2))
 }
+
+# functions that plot the test figs -------------------------------------------
 
 basic_marginals <- list(
   "basic density" = function() ggMarg2("density"),
@@ -106,6 +110,8 @@ funList <- list(
   grouping_feature = grouping_feature,
   transforms = transforms
 )
+
+# functions that help with running tests against specific package versions ----
 
 expectDopp2 <- function(funName, ggplot2Version) {
 

--- a/tests/testthat/helper-funs.R
+++ b/tests/testthat/helper-funs.R
@@ -113,20 +113,6 @@ funList <- list(
 
 # functions that help with running tests against specific package versions ----
 
-expectDopp2 <- function(funName, ggplot2Version) {
-  
-  # make sure expected figure already exists on disk...that way, tests will 
-  # never pass when a test case is skipped if the expected fig doesn't exist
-  path <- paste0("ggMarginal/ggplot2-", ggplot2Version)
-  fileName <- paste0(vdiffr:::str_standardise(funName), ".svg")
-  file <- file.path("../figs", path, fileName)
-  stopifnot(file.exists(file))
-  
-  vdiffr::expect_doppelganger(
-    funName, printMuffled(funList[[funName]]()), path = path
-  )
-}
-
 # withVersions is essentially the same function as with_pkg_version that
 # appears here: https://gist.github.com/jimhester/d7aeb95bbed02f2985a87c2a3ede19f5.
 # This function allows us to run unit tests under different versions of ggplot2,

--- a/tests/testthat/helper-funs.R
+++ b/tests/testthat/helper-funs.R
@@ -21,7 +21,7 @@ basicScatPWithLims <- function() {
 
 # functions that plot the test figs -------------------------------------------
 
-basic_marginals <- list(
+basicMarginals <- list(
   "basic density" = function() ggMarg2("density"),
   "basic histogram" = function() ggMarg2("histogram"),
   "basic boxplot" = function() ggMarg2("boxplot"),
@@ -31,7 +31,7 @@ basic_marginals <- list(
     data = mtcars, x = "mpg", y = "disp", type = "density"
   )
 )
-other_params <- list(
+otherParams <- list(
   "only x margin" = function() ggMarg2("density", margins = "x"),
   "smaller marginal plots" = function() ggMarg2("density", size = 10),
   "both hists red col" = function() ggMarg2("histogram", colour = "red"),
@@ -39,7 +39,7 @@ other_params <- list(
     "histogram", xparams = list(colour = "red", fill = "red")
   )
 )
-misc_issues <- list(
+miscIssues <- list(
   "theme bw" = function() ggMarginal(
     basicScatP() + ggplot2::theme_bw(), type = "density"
   ),
@@ -64,7 +64,7 @@ misc_issues <- list(
     basicScatP(), type = "densigram", fill = "blue"
   )
 )
-grouping_feature <- list(
+groupingFeature <- list(
   "col and fill mapped" = function() ggMarginal(
     margMapP(), groupColour = TRUE, groupFill = TRUE
   ),
@@ -104,17 +104,17 @@ transforms <- list(
 )
 
 funList <- list(
-  basic_marginals = basic_marginals,
-  other_params = other_params,
-  misc_issues = misc_issues,
-  grouping_feature = grouping_feature,
-  transforms = transforms
+  "ggMarginal can produce basic marginal plots" = basicMarginals,
+  "ggMarginal's other params work" = otherParams,
+  "Misc issues are solved" = miscIssues,
+  "Grouping feature works as expected" = groupingFeature,
+  "Transforms to scatter plot scales are reflected in marginals" = transforms
 )
 
 # functions that help with running tests against specific package versions ----
 
 expectDopp2 <- function(funName, ggplot2Version) {
-
+  
   # make sure expected figure already exists on disk...that way, tests will 
   # never pass when a test case is skipped if the expected fig doesn't exist
   path <- paste0("ggMarginal/ggplot2-", ggplot2Version)
@@ -178,7 +178,7 @@ getSnapShotRepo <- function(package, version) {
   )
 }
 
-is_current_version <- function(version, versions) {
+isCurrentVersion <- function(version, versions) {
   all(
     vapply(
       versions, function(x) utils::compareVersion(version, x) == 1, logical(1)
@@ -190,7 +190,7 @@ attemptRepoDate <- function(package, version) {
   arch <- devtools:::package_find_repo(package, "https://cloud.r-project.org")
   versions <- gsub(".*/[^_]+_([^[:alpha:]]+)\\.tar\\.gz", "\\1", arch$path)
   date <- arch[versions == version, "mtime", drop = TRUE]
-  if (length(date) == 0 && is_current_version(version, versions)) {
+  if (length(date) == 0 && isCurrentVersion(version, versions)) {
     return("https://cloud.r-project.org")
   }
   dateString <- as.character(as.Date(date, format = "%Y/%m/%d") + 2)

--- a/tests/testthat/render-figs.R
+++ b/tests/testthat/render-figs.R
@@ -39,7 +39,7 @@ asSvgFile <- function(funName, ggplot2Version = "2.2.1") {
 # Function to render all figures under different versions of ggplot2. Note, you
 # must have ggExtra version >= 0.6.1.9000 (commit 4b31c7cf or after) for these
 # figures to render correctly.
-renderAllFigsApply <- function(ggplot2Versions) {
+renderFigsApply <- function(ggplot2Versions) {
   withVersions(
     vdiffr = "0.1.1", fontquiver = "0.2.1", svglite = "1.2.0", code = {
       sapply(ggplot2Versions, function(ggplot2Version) {
@@ -63,4 +63,4 @@ renderAllFigsApply <- function(ggplot2Versions) {
 # This was called once to create all the expected versions of the test figures.
 # It should be re-run each time a new test figure is added to the function list
 # (funList) in  helper-funs.R (funList contains the code to create the figures).
-renderAllFigsApply(ggplot2Versions)
+renderFigsApply(ggplot2Versions)

--- a/tests/testthat/render-figs.R
+++ b/tests/testthat/render-figs.R
@@ -44,11 +44,13 @@ renderAllFigsApply <- function(ggplot2Versions) {
     vdiffr = "0.1.1", fontquiver = "0.2.1", svglite = "1.2.0", code = {
       sapply(ggplot2Versions, function(ggplot2Version) {
         withVersions(ggplot2 = ggplot2Version, code = {
+          funList <- unlist(funList)
           sapply(
             names(funList), function(x) {
+              nm <- gsub(".*\\.", "", x)
               writeSvg(
                 p = funList[[x]](),
-                file = asSvgFile(x, ggplot2Version)
+                file = asSvgFile(nm, ggplot2Version)
               ) 
             }
           )

--- a/tests/testthat/test-ggMarginal.R
+++ b/tests/testthat/test-ggMarginal.R
@@ -1,4 +1,4 @@
-expectDopp2 <- function(testName, funName, ggplot2Version) {
+expectDoppelganger2 <- function(testName, funName, ggplot2Version) {
   
   path <- paste0("ggMarginal/ggplot2-", ggplot2Version)
   
@@ -21,7 +21,10 @@ runMarginalTests <- function(ggplot2Version) {
   testNames <- names(funList)
   sapply(testNames, function(x) {
     test_that(x, {
-      sapply(names(funList[[x]]), function(y) expectDopp2(x, y, ggplot2Version))
+      sapply(
+        names(funList[[x]]), 
+        function(y) expectDoppelganger2(x, y, ggplot2Version)
+      )
     })
   })
 }

--- a/tests/testthat/test-ggMarginal.R
+++ b/tests/testthat/test-ggMarginal.R
@@ -1,52 +1,28 @@
+expectDopp2 <- function(testName, funName, ggplot2Version) {
+  
+  path <- paste0("ggMarginal/ggplot2-", ggplot2Version)
+  
+  # make sure expected figure already exists on disk...that way, tests will 
+  # never pass when a test case is skipped if the expected fig doesn't exist
+  fileName <- paste0(vdiffr:::str_standardise(funName), ".svg")
+  file <- file.path("../figs", path, fileName)
+  stopifnot(file.exists(file))
+  
+  vdiffr::expect_doppelganger(
+    funName, printMuffled(funList[[testName]][[funName]]()), path = path
+  )
+}
+
 runMarginalTests <- function(ggplot2Version) {
+  
   context <- paste("ggMarginal under ggplot2 version", ggplot2Version)
-
   context(context)
-
-  test_that("ggMarginal can produce basic marginal plots", {
-    sapply(c(
-      "basic density", "basic histogram", "basic boxplot", "basic densigram",
-      "basic violin plot", "scatter plot from data"
-    ), function(x) expectDopp2(x, ggplot2Version))
-  })
-
-  test_that("ggMarginal's other params work", {
-    sapply(c(
-      "only x margin", "smaller marginal plots", "both hists red col",
-      "top hist red col and fill"
-    ), function(x) expectDopp2(x, ggplot2Version))
-  })
-
-  test_that("Misc. issues are solved", {
-    sapply(c(
-      "theme bw", "legend and title",
-      "flipped coord where x is drat and y is wt",
-      "subtitle but no title",
-      "geom_line provided as first geom",
-      "no density fill for densigrams"
-    ), function(x) expectDopp2(x, ggplot2Version))
-  })
-
-  test_that("Grouping feature works as expected", {
-    sapply(
-      c(
-        "col and fill mapped", "fill mapped with low alpha",
-        "colour mapped with grey fill",
-        "colour mapped and colour param provided",
-        "colour & fill mapped and both params provided"
-      ), function(x) expectDopp2(x, ggplot2Version)
-    )
-  })
-
-  test_that("Transforms to scatter plot scales are reflected in marginals", {
-    sapply(
-      c(
-        "x-axis limits using scale_x_continuous",
-        "axis limits using xlim and ylim", "x-axis limits for histograms",
-        "x-axis limits for marginals with y aes", "x and y scale_reverse",
-        "geom_smooth with aligned marg plots"
-      ), function(x) expectDopp2(x, ggplot2Version)
-    )
+  
+  testNames <- names(funList)
+  sapply(testNames, function(x) {
+    test_that(x, {
+      sapply(names(funList[[x]]), function(y) expectDopp2(x, y, ggplot2Version))
+    })
   })
 }
 


### PR DESCRIPTION
This PR refactors ggExtra's test code, closing #100. The main refactoring invovles grouping the functions in `funList` together based on which `test_that()` call they appear in. This makes the organization of the functions clearer in helper-funs.R, and allows us to specify the names of the functions in only one place (they were previously having to appear in both helper-funs.R as well as in test-ggMarginal.R...1da367ac55cd01f9923ab649cb0472963717b431 fixes this). A few notes regarding the notes that appear in #100:

> * have the code in test-ggMarginal check that all of the figs in tests/figs have a corresponding function in `funList` (in case you forget to add call to a function in test-ggMarinal)

`runMarginalTests()` now loops over all the functions in `funList`, so this is no longer an issue.

> * `runInternalTestsApply()` only needs to test under latest version of ggplot2

It's probably not necessary to run the ggplot2 internals tests against each ggplot2 version, but i'd like to keep it as is for now. 