### PR TITLE
Fix the "two chunk" requirement for rendering ggMarginalPlots in RMarkdown docs

### DIFF
--- a/R/ggMarginal.R
+++ b/R/ggMarginal.R
@@ -202,5 +202,13 @@ ggMarginal <- function(p, data, x, y,
 #' @keywords internal
 print.ggExtraPlot <- function(x, newpage = grDevices::dev.interactive(), ...) {
   if (newpage) grid::grid.newpage()
-  grid::grid.draw(x)
+  if (isTRUE(getOption("rstudio.notebook.executing"))) {
+    x <- ggplot2::ggplot() +
+      ggplot2::geom_blank() +
+      ggplot2::annotation_custom(x) +
+      ggplot2::theme_void()
+    print(x)
+  } else {
+    grid::grid.draw(x)
+  }
 }

--- a/R/ggMarginal.R
+++ b/R/ggMarginal.R
@@ -5,7 +5,7 @@
 #'
 #' @note The \code{grid} and \code{gtable} packages are required for this
 #' function.
-#' @param p A ggplot2 scatterplot to add marginal plots to.  If \code{p} is
+#' @param p A ggplot2 scatterplot to add marginal plots to. If \code{p} is
 #' not provided, then all of \code{data}, \code{x}, and \code{y} must be
 #' provided.
 #' @param data The data.frame to use for creating the marginal plots. Optional

--- a/R/plotCount.R
+++ b/R/plotCount.R
@@ -7,11 +7,11 @@
 #' table.
 #'
 #' If a data.frame is provided, it must have exactly two columns:
-#' the first column contains the of unique values in the data, and the second
+#' the first column contains the unique values in the data, and the second
 #' column is the corresponding integer frequencies to each value.
 #'
 #' If a table is provided, it must have exactly one row: the rownames are the
-#' unique values in the data, and the row values are the  corresponding integer
+#' unique values in the data, and the row values are the corresponding integer
 #' frequencies to each value.
 #'
 #' @param x A data.frame or table. See 'Details' for more information.

--- a/man/ggMarginal.Rd
+++ b/man/ggMarginal.Rd
@@ -10,7 +10,7 @@ ggMarginal(p, data, x, y, type = c("density", "histogram", "boxplot",
   groupFill = FALSE)
 }
 \arguments{
-\item{p}{A ggplot2 scatterplot to add marginal plots to.  If \code{p} is
+\item{p}{A ggplot2 scatterplot to add marginal plots to. If \code{p} is
 not provided, then all of \code{data}, \code{x}, and \code{y} must be
 provided.}
 

--- a/man/plotCount.Rd
+++ b/man/plotCount.Rd
@@ -25,11 +25,11 @@ The argument to this function is expected to be either a data.frame or a
 table.
 
 If a data.frame is provided, it must have exactly two columns:
-the first column contains the of unique values in the data, and the second 
+the first column contains the unique values in the data, and the second
 column is the corresponding integer frequencies to each value.
 
-If a table is provided, it must have exactly one row: the rownames are the 
-unique values in the data, and the row values are the  corresponding integer 
+If a table is provided, it must have exactly one row: the rownames are the
+unique values in the data, and the row values are the corresponding integer
 frequencies to each value.
 }
 \examples{


### PR DESCRIPTION
This PR provides my best attempt at solving #147. It has the issue of the leading blank page that I mentioned in that issue thread, though other than that it pretty much gets the job done. I'll update the README once/if this PR gets the all clear. A few questions that may cross your mind:

1. Why not use the same solution of converting the `ggMarginalPlot` into a `ggplot`, regardless of whether the plotting code is evaluated in an RMarkdown doc? I.e., why not just always use lines https://github.com/daattali/ggExtra/compare/master...crew102:ggmarginals-in-rmarkdown?expand=1#diff-01bed624663254513627969554598880R206-R210?

If we convert to a ggplot object, we end up with a leading blank page when plotting to non-interactive devices. This can be fixed by using `ggsave()` instead of following the workflow of opening up a graphics device, plotting, then closing the device, but that would require people change all their code that writes `ggMarginalPlot`s to files. 

2. Will the current solution still allow users to use the two chunk solution proposed in the README?

Yes, the two chunks approach will still produce the same results as it always has. This is still the only way to avoid the leading blank page when running a chunk semi-interactively (i.e., when pressing the "run current chunk" button).

3. Why do you have to convert the `ggExtraPlot`/`gtable` object returned by `ggMarginal()` into a `ggplot` to address the issues mentioned in #89 and https://support.rstudio.com/hc/en-us/community/posts/239529128-Notebooks-grid-newpage? 

No idea.
  
4. Could the solution of converting the `ggMarginalPlot` to a `ggplot` somehow provide the functionality desired in #129? 

I don't think so, though I didn't take a very close look. Essentially when you convert the `ggMarginalPlot` to a `ggplot`, the entire plot (including the marginal plots) are considered the plot. So, for example, if you tried to change the theme of the plot, it would change the theme of the scatter plot and the marginal plots. It may be possible to pull out the scatter plot and manipulate it on its own, but I don't think that's @IndrajeetPatil was going for in #129.