### PR TITLE
Fix issue where grouped boxplots and violin plots were variable width…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggExtra
 Title: Add Marginal Histograms to 'ggplot2', and More 'ggplot2' Enhancements
-Version: 0.10.0
+Version: 0.10.9000
 Authors@R: c(
     person("Dean", "Attali", , "daattali@gmail.com", role = c("aut", "cre")),
     person("Christopher", "Baker", , "chriscrewbaker@gmail.com", role = "aut")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ggExtra
 Title: Add Marginal Histograms to 'ggplot2', and More 'ggplot2' Enhancements
-Version: 0.10.9000
+Version: 0.10.0.9000
 Authors@R: c(
     person("Dean", "Attali", , "daattali@gmail.com", role = c("aut", "cre")),
     person("Christopher", "Baker", , "chriscrewbaker@gmail.com", role = "aut")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# ggExtra 0.10.9000
+
+2023-01-27
+
+- Fixed issue where grouped boxplots and violin plots were variable widths (#173)
+
 # ggExtra 0.10.0
 
 2022-03-22

--- a/R/ggMarginal-MarginalPlot.R
+++ b/R/ggMarginal-MarginalPlot.R
@@ -53,7 +53,11 @@ MarginalPlot <- R6::R6Class("MarginalPlot",
         scatDF$x <- scatDF$y
       }
       
-      scatDF$y <- scatDF$x
+      # We never want to actually use the y aesthetic when creating the marginal
+      # plots, but geom_violin requires it. Also note that, in order to make the
+      # widths of violin and boxplots the same in the marginal plots, we need a
+      # constant y.
+      scatDF$y <- 1
       scatDF[, c("x", "y", "fill", "colour", "group")]
     },
     
@@ -246,15 +250,8 @@ MarginalPlot <- R6::R6Class("MarginalPlot",
     
     addLimits = function(margThemed) {
       limits <- private$getLimits()
-      # for plots with y aes we have to use scale_y_continuous instead of
-      # scale_x_continuous.
-      if (self$type %in% c("boxplot", "violin")) {
-        margThemed +
-          ggplot2::scale_y_continuous(limits = limits, oob = scales::squish)
-      } else {
-        margThemed +
-          ggplot2::scale_x_continuous(limits = limits, oob = scales::squish)
-      }
+      margThemed + 
+        ggplot2::scale_x_continuous(limits = limits, oob = scales::squish)
     },
 
     getPanelScale = function(marg) {
@@ -275,13 +272,7 @@ MarginalPlot <- R6::R6Class("MarginalPlot",
     },
     
     needsFlip = function() {
-      # If the marginal plot is: (for the x margin (top) and is a boxplot) or
-      #                          (for the y margin (right) and is not a boxplot),
-      # ... then have to flip
-      topAndBoxP <- self$marg == "x" && self$type %in% c("boxplot", "violin")
-      rightAndNonBoxP <- 
-        self$marg == "y" && !(self$type %in% c("boxplot", "violin"))
-      topAndBoxP || rightAndNonBoxP
+      self$marg == "y"
     },
     
     # Get the axis range of the x or y axis of the given ggplot build object

--- a/tests/figs/ggMarginal/ggplot2-3.3.0/widths-of-boxplots-are-the-same-within-a-marginal.svg
+++ b/tests/figs/ggMarginal/ggplot2-3.3.0/widths-of-boxplots-are-the-same-within-a-marginal.svg
@@ -1,0 +1,165 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw2MTcuNDR8OTAuNTh8NTc2LjAw'>
+    <rect x='0.00' y='90.58' width='617.44' height='485.42' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw2MTcuNDR8OTAuNTh8NTc2LjAw)'>
+<rect x='0.00' y='90.58' width='617.44' height='485.42' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzYuODV8NTQ5LjY2fDkwLjU4fDU0My41MQ=='>
+    <rect x='36.85' y='90.58' width='512.81' height='452.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzYuODV8NTQ5LjY2fDkwLjU4fDU0My41MQ==)'>
+<rect x='36.85' y='90.58' width='512.81' height='452.92' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='36.85,524.82 549.66,524.82 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,429.95 549.66,429.95 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,335.07 549.66,335.07 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,240.20 549.66,240.20 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,145.33 549.66,145.33 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='58.61,543.51 58.61,90.58 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='177.81,543.51 177.81,90.58 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='297.01,543.51 297.01,90.58 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='416.21,543.51 416.21,90.58 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='535.41,543.51 535.41,90.58 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,477.38 549.66,477.38 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,382.51 549.66,382.51 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,287.64 549.66,287.64 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,192.76 549.66,192.76 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,97.89 549.66,97.89 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='118.21,543.51 118.21,90.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='237.41,543.51 237.41,90.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='356.61,543.51 356.61,90.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='475.81,543.51 475.81,90.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<circle cx='192.11' cy='306.61' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='222.51' cy='306.61' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='156.35' cy='316.10' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='263.04' cy='462.20' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='289.86' cy='448.92' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='292.24' cy='522.92' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='305.35' cy='437.54' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='260.06' cy='346.46' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='255.29' cy='302.82' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='289.86' cy='302.82' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='289.86' cy='302.82' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='364.95' cy='464.10' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='324.43' cy='464.10' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='330.39' cy='464.10' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='505.61' cy='490.66' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='526.35' cy='477.38' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='516.94' cy='433.74' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='142.05' cy='272.46' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='72.32' cy='111.17' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='98.54' cy='245.89' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='173.64' cy='344.56' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='299.39' cy='522.92' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='289.26' cy='448.92' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='337.54' cy='338.87' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='338.13' cy='462.20' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='110.46' cy='272.46' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='134.90' cy='206.05' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='60.16' cy='331.28' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='257.67' cy='245.89' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='209.99' cy='359.74' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='305.35' cy='374.92' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='211.18' cy='266.76' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='31.92' y='480.41' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='31.92' y='385.54' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>3.5</text>
+<text x='31.92' y='290.66' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>4.0</text>
+<text x='31.92' y='195.79' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text x='31.92' y='100.92' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<polyline points='34.11,477.38 36.85,477.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.11,382.51 36.85,382.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.11,287.64 36.85,287.64 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.11,192.76 36.85,192.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.11,97.89 36.85,97.89 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='118.21,546.25 118.21,543.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='237.41,546.25 237.41,543.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='356.61,546.25 356.61,543.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='475.81,546.25 475.81,543.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='118.21' y='554.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='237.41' y='554.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='356.61' y='554.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='475.81' y='554.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='293.25' y='566.63' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='11.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(14.65,317.05) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='18.96px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<rect x='560.62' y='286.62' width='56.82' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='566.10' y='300.81' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='45.86px' lengthAdjust='spacingAndGlyphs'>factor(vs)</text>
+<rect x='566.10' y='307.43' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<circle cx='574.74' cy='316.07' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<rect x='566.10' y='324.71' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<circle cx='574.74' cy='333.35' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<text x='588.86' y='319.10' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='588.86' y='336.38' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
+</g>
+<defs>
+  <clipPath id='cpMzYuODV8NTQ5LjY2fDAuMDB8OTAuNTg='>
+    <rect x='36.85' y='0.00' width='512.81' height='90.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzYuODV8NTQ5LjY2fDAuMDB8OTAuNTg=)'>
+<circle cx='505.61' cy='66.96' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; stroke-opacity: 0.50; fill: #00FF00; fill-opacity: 0.50;' />
+<circle cx='526.35' cy='66.96' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; stroke-opacity: 0.50; fill: #00FF00; fill-opacity: 0.50;' />
+<circle cx='516.94' cy='66.96' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; stroke-opacity: 0.50; fill: #00FF00; fill-opacity: 0.50;' />
+<circle cx='134.90' cy='66.96' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; stroke-opacity: 0.50; fill: #00FF00; fill-opacity: 0.50;' />
+<line x1='337.99' y1='66.96' x2='364.95' y2='66.96' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' />
+<line x1='265.57' y1='66.96' x2='192.11' y2='66.96' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' />
+<polygon points='337.99,86.47 265.57,86.47 265.57,47.46 337.99,47.46 337.99,86.47 ' style='stroke-width: 1.07; stroke: #00FF00; fill: #FFFFFF; fill-opacity: 0.50;' />
+<line x1='305.35' y1='86.47' x2='305.35' y2='47.46' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt;' />
+<line x1='262.29' y1='23.62' x2='292.24' y2='23.62' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' />
+<line x1='118.36' y1='23.62' x2='60.16' y2='23.62' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' />
+<polygon points='262.29,43.13 118.36,43.13 118.36,4.12 262.29,4.12 262.29,43.13 ' style='stroke-width: 1.07; stroke: #0000FF; fill: #FFFFFF; fill-opacity: 0.50;' />
+<line x1='192.41' y1='43.13' x2='192.41' y2='4.12' style='stroke-width: 2.13; stroke: #0000FF; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNjE3LjQ0fDcyMC4wMHw5MC41OHw1NDMuNTE='>
+    <rect x='617.44' y='90.58' width='102.56' height='452.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjE3LjQ0fDcyMC4wMHw5MC41OHw1NDMuNTE=)'>
+<line x1='644.18' y1='344.09' x2='644.18' y2='206.05' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' />
+<line x1='644.18' y1='464.10' x2='644.18' y2='522.92' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' />
+<polygon points='622.10,344.09 622.10,464.10 666.26,464.10 666.26,344.09 622.10,344.09 ' style='stroke-width: 1.07; stroke: #00FF00; fill: #FFFFFF; fill-opacity: 0.50;' />
+<line x1='622.10' y1='443.23' x2='666.26' y2='443.23' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt;' />
+<circle cx='693.26' cy='462.20' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; stroke-opacity: 0.50; fill: #0000FF; fill-opacity: 0.50;' />
+<circle cx='693.26' cy='522.92' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; stroke-opacity: 0.50; fill: #0000FF; fill-opacity: 0.50;' />
+<circle cx='693.26' cy='111.17' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; stroke-opacity: 0.50; fill: #0000FF; fill-opacity: 0.50;' />
+<line x1='693.26' y1='272.46' x2='693.26' y2='245.89' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' />
+<line x1='693.26' y1='341.24' x2='693.26' y2='346.46' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' />
+<polygon points='671.17,272.46 671.17,341.24 715.34,341.24 715.34,272.46 671.17,272.46 ' style='stroke-width: 1.07; stroke: #0000FF; fill: #FFFFFF; fill-opacity: 0.50;' />
+<line x1='671.17' y1='302.82' x2='715.34' y2='302.82' style='stroke-width: 2.13; stroke: #0000FF; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+</svg>

--- a/tests/figs/ggMarginal/ggplot2-3.4.0/widths-of-boxplots-are-the-same-within-a-marginal.svg
+++ b/tests/figs/ggMarginal/ggplot2-3.4.0/widths-of-boxplots-are-the-same-within-a-marginal.svg
@@ -1,0 +1,165 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+    .svglite text {
+      white-space: pre;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMC4wMHw2MTcuNDR8OTAuNTh8NTc2LjAw'>
+    <rect x='0.00' y='90.58' width='617.44' height='485.42' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw2MTcuNDR8OTAuNTh8NTc2LjAw)'>
+<rect x='0.00' y='90.58' width='617.44' height='485.42' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpMzYuODV8NTQ5LjY2fDkwLjU4fDU0My41MQ=='>
+    <rect x='36.85' y='90.58' width='512.81' height='452.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzYuODV8NTQ5LjY2fDkwLjU4fDU0My41MQ==)'>
+<rect x='36.85' y='90.58' width='512.81' height='452.92' style='stroke-width: 1.07; stroke: none; fill: #EBEBEB;' />
+<polyline points='36.85,524.82 549.66,524.82 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,429.95 549.66,429.95 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,335.07 549.66,335.07 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,240.20 549.66,240.20 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,145.33 549.66,145.33 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='58.61,543.51 58.61,90.58 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='177.81,543.51 177.81,90.58 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='297.01,543.51 297.01,90.58 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='416.21,543.51 416.21,90.58 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='535.41,543.51 535.41,90.58 ' style='stroke-width: 0.53; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,477.38 549.66,477.38 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,382.51 549.66,382.51 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,287.64 549.66,287.64 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,192.76 549.66,192.76 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='36.85,97.89 549.66,97.89 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='118.21,543.51 118.21,90.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='237.41,543.51 237.41,90.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='356.61,543.51 356.61,90.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<polyline points='475.81,543.51 475.81,90.58 ' style='stroke-width: 1.07; stroke: #FFFFFF; stroke-linecap: butt;' />
+<circle cx='192.11' cy='306.61' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='222.51' cy='306.61' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='156.35' cy='316.10' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='263.04' cy='462.20' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='289.86' cy='448.92' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='292.24' cy='522.92' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='305.35' cy='437.54' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='260.06' cy='346.46' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='255.29' cy='302.82' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='289.86' cy='302.82' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='289.86' cy='302.82' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='364.95' cy='464.10' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='324.43' cy='464.10' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='330.39' cy='464.10' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='505.61' cy='490.66' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='526.35' cy='477.38' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='516.94' cy='433.74' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='142.05' cy='272.46' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='72.32' cy='111.17' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='98.54' cy='245.89' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='173.64' cy='344.56' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='299.39' cy='522.92' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='289.26' cy='448.92' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='337.54' cy='338.87' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='338.13' cy='462.20' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='110.46' cy='272.46' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='134.90' cy='206.05' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='60.16' cy='331.28' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<circle cx='257.67' cy='245.89' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='209.99' cy='359.74' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='305.35' cy='374.92' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<circle cx='211.18' cy='266.76' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='31.92' y='480.41' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>3.0</text>
+<text x='31.92' y='385.54' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>3.5</text>
+<text x='31.92' y='290.66' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>4.0</text>
+<text x='31.92' y='195.79' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>4.5</text>
+<text x='31.92' y='100.92' text-anchor='end' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='12.24px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<polyline points='34.11,477.38 36.85,477.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.11,382.51 36.85,382.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.11,287.64 36.85,287.64 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.11,192.76 36.85,192.76 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='34.11,97.89 36.85,97.89 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='118.21,546.25 118.21,543.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='237.41,546.25 237.41,543.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='356.61,546.25 356.61,543.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='475.81,546.25 475.81,543.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='118.21' y='554.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='237.41' y='554.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='356.61' y='554.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>4</text>
+<text x='475.81' y='554.50' text-anchor='middle' style='font-size: 8.80px;fill: #4D4D4D; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>5</text>
+<text x='293.25' y='566.63' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='11.00px' lengthAdjust='spacingAndGlyphs'>wt</text>
+<text transform='translate(14.65,317.05) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='18.96px' lengthAdjust='spacingAndGlyphs'>drat</text>
+<rect x='560.62' y='286.62' width='56.82' height='60.85' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<text x='566.10' y='300.81' style='font-size: 11.00px; font-family: "Liberation Sans";' textLength='45.86px' lengthAdjust='spacingAndGlyphs'>factor(vs)</text>
+<rect x='566.10' y='307.43' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<circle cx='574.74' cy='316.07' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; fill: #00FF00;' />
+<rect x='566.10' y='324.71' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #F2F2F2;' />
+<circle cx='574.74' cy='333.35' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; fill: #0000FF;' />
+<text x='588.86' y='319.10' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='588.86' y='336.38' style='font-size: 8.80px; font-family: "Liberation Sans";' textLength='4.90px' lengthAdjust='spacingAndGlyphs'>1</text>
+</g>
+<defs>
+  <clipPath id='cpMzYuODV8NTQ5LjY2fDAuMDB8OTAuNTg='>
+    <rect x='36.85' y='0.00' width='512.81' height='90.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzYuODV8NTQ5LjY2fDAuMDB8OTAuNTg=)'>
+<circle cx='505.61' cy='66.96' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; stroke-opacity: 0.50; fill: #00FF00; fill-opacity: 0.50;' />
+<circle cx='526.35' cy='66.96' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; stroke-opacity: 0.50; fill: #00FF00; fill-opacity: 0.50;' />
+<circle cx='516.94' cy='66.96' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; stroke-opacity: 0.50; fill: #00FF00; fill-opacity: 0.50;' />
+<circle cx='134.90' cy='66.96' r='1.95' style='stroke-width: 0.71; stroke: #00FF00; stroke-opacity: 0.50; fill: #00FF00; fill-opacity: 0.50;' />
+<line x1='337.99' y1='66.96' x2='364.95' y2='66.96' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' />
+<line x1='265.57' y1='66.96' x2='192.11' y2='66.96' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' />
+<polygon points='337.99,86.47 265.57,86.47 265.57,47.46 337.99,47.46 337.99,86.47 ' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF; fill-opacity: 0.50;' />
+<line x1='305.35' y1='86.47' x2='305.35' y2='47.46' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; stroke-linejoin: miter;' />
+<line x1='262.29' y1='23.62' x2='292.24' y2='23.62' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' />
+<line x1='118.36' y1='23.62' x2='60.16' y2='23.62' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' />
+<polygon points='262.29,43.13 118.36,43.13 118.36,4.12 262.29,4.12 262.29,43.13 ' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF; fill-opacity: 0.50;' />
+<line x1='192.41' y1='43.13' x2='192.41' y2='4.12' style='stroke-width: 2.13; stroke: #0000FF; stroke-linecap: butt; stroke-linejoin: miter;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNjE3LjQ0fDcyMC4wMHw5MC41OHw1NDMuNTE='>
+    <rect x='617.44' y='90.58' width='102.56' height='452.92' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNjE3LjQ0fDcyMC4wMHw5MC41OHw1NDMuNTE=)'>
+<line x1='644.18' y1='344.09' x2='644.18' y2='206.05' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' />
+<line x1='644.18' y1='464.10' x2='644.18' y2='522.92' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt;' />
+<polygon points='622.10,344.09 622.10,464.10 666.26,464.10 666.26,344.09 622.10,344.09 ' style='stroke-width: 1.07; stroke: #00FF00; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF; fill-opacity: 0.50;' />
+<line x1='622.10' y1='443.23' x2='666.26' y2='443.23' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; stroke-linejoin: miter;' />
+<circle cx='693.26' cy='462.20' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; stroke-opacity: 0.50; fill: #0000FF; fill-opacity: 0.50;' />
+<circle cx='693.26' cy='522.92' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; stroke-opacity: 0.50; fill: #0000FF; fill-opacity: 0.50;' />
+<circle cx='693.26' cy='111.17' r='1.95' style='stroke-width: 0.71; stroke: #0000FF; stroke-opacity: 0.50; fill: #0000FF; fill-opacity: 0.50;' />
+<line x1='693.26' y1='272.46' x2='693.26' y2='245.89' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' />
+<line x1='693.26' y1='341.24' x2='693.26' y2='346.46' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt;' />
+<polygon points='671.17,272.46 671.17,341.24 715.34,341.24 715.34,272.46 671.17,272.46 ' style='stroke-width: 1.07; stroke: #0000FF; stroke-linecap: butt; stroke-linejoin: miter; fill: #FFFFFF; fill-opacity: 0.50;' />
+<line x1='671.17' y1='302.82' x2='715.34' y2='302.82' style='stroke-width: 2.13; stroke: #0000FF; stroke-linecap: butt; stroke-linejoin: miter;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+</svg>

--- a/tests/testthat/helper-funs.R
+++ b/tests/testthat/helper-funs.R
@@ -95,6 +95,9 @@ groupingFeature <- list(
   "groupFill doesn't impact hist heights - with fill" = function() ggMarginal(
     margMapP(), type = "histogram", xparams = list(binwidth = .3),
     groupFill = TRUE
+  ),
+  "widths of boxplots are the same within a marginal" = function() ggMarginal(
+    margMapP(), type = "boxplot", groupColour = TRUE
   )
 )
 transforms <- list(


### PR DESCRIPTION
This PR addresses the issue mentioned in #169. Namely, we get varying widths for boxplots and violins b/c we were providing a data-based y aesthetic in the mapping for those (as opposed to what we're doing now, which is providing a constant for y). Incidentally, I previously thought it was necessary to provide `y` for both boxplots and violins, now I see it's just for violins.

Here's what it looks like with the current version of ggExtra and then with the version in this PR.

## Current version

``` r
library(ggplot2)
library(ggExtra)

p <- ggplot(mtcars, aes(x = mpg, y = wt, colour = factor(am))) + geom_point()

ggMarginal(p, type = "boxplot", groupFill = TRUE)
```

![](https://i.imgur.com/kXCUHQx.png)

``` r

# Not related to this PR: Looks like it's another bug related to rendering 
# ggMarinals. Have to call this or it all gets overwritten on the same "page" 
# on the device.
grid::grid.newpage()

ggMarginal(p, type = "violin", groupFill = TRUE)
#> Warning: `position_dodge()` requires non-overlapping x intervals
#> `position_dodge()` requires non-overlapping x intervals
```

![](https://i.imgur.com/PNVcGoO.png)

<sup>Created on 2023-01-25 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.1.2 (2021-11-01)
#>  os       macOS Big Sur 10.16
#>  system   x86_64, darwin17.0
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       America/New_York
#>  date     2023-01-25
#>  pandoc   2.19.2 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version date (UTC) lib source
#>  assertthat    0.2.1   2019-03-21 [1] CRAN (R 4.1.0)
#>  backports     1.4.1   2021-12-13 [1] CRAN (R 4.1.0)
#>  cli           3.6.0   2023-01-09 [1] CRAN (R 4.1.2)
#>  colorspace    2.0-3   2022-02-21 [1] CRAN (R 4.1.2)
#>  curl          4.3.2   2021-06-23 [1] CRAN (R 4.1.0)
#>  DBI           1.1.2   2021-12-20 [1] CRAN (R 4.1.0)
#>  digest        0.6.29  2021-12-01 [1] CRAN (R 4.1.0)
#>  dplyr         1.0.8   2022-02-08 [1] CRAN (R 4.1.2)
#>  ellipsis      0.3.2   2021-04-29 [1] CRAN (R 4.1.0)
#>  evaluate      0.15    2022-02-18 [1] CRAN (R 4.1.2)
#>  fansi         1.0.4   2023-01-22 [1] CRAN (R 4.1.2)
#>  farver        2.1.1   2022-07-06 [1] CRAN (R 4.1.2)
#>  fastmap       1.1.0   2021-01-25 [1] CRAN (R 4.1.0)
#>  fs            1.5.2   2021-12-08 [1] CRAN (R 4.1.0)
#>  generics      0.1.2   2022-01-31 [1] CRAN (R 4.1.2)
#>  ggExtra     * 0.10.0  2022-03-23 [1] CRAN (R 4.1.2)
#>  ggplot2     * 3.4.0   2022-11-04 [1] CRAN (R 4.1.2)
#>  glue          1.6.2   2022-02-24 [1] CRAN (R 4.1.2)
#>  gtable        0.3.1   2022-09-01 [1] CRAN (R 4.1.2)
#>  highr         0.9     2021-04-16 [1] CRAN (R 4.1.0)
#>  htmltools     0.5.2   2021-08-25 [1] CRAN (R 4.1.0)
#>  httpuv        1.6.5   2022-01-05 [1] CRAN (R 4.1.2)
#>  httr          1.4.2   2020-07-20 [1] CRAN (R 4.1.0)
#>  knitr         1.37    2021-12-16 [1] CRAN (R 4.1.0)
#>  labeling      0.4.2   2020-10-20 [1] CRAN (R 4.1.0)
#>  later         1.3.0   2021-08-18 [1] CRAN (R 4.1.0)
#>  lifecycle     1.0.3   2022-10-07 [1] CRAN (R 4.1.2)
#>  magrittr      2.0.3   2022-03-30 [1] CRAN (R 4.1.2)
#>  mime          0.12    2021-09-28 [1] CRAN (R 4.1.0)
#>  miniUI        0.1.1.1 2018-05-18 [1] CRAN (R 4.1.0)
#>  munsell       0.5.0   2018-06-12 [1] CRAN (R 4.1.0)
#>  pillar        1.8.1   2022-08-19 [1] CRAN (R 4.1.2)
#>  pkgconfig     2.0.3   2019-09-22 [1] CRAN (R 4.1.0)
#>  promises      1.2.0.1 2021-02-11 [1] CRAN (R 4.1.0)
#>  purrr         0.3.4   2020-04-17 [1] CRAN (R 4.1.0)
#>  R.cache       0.15.0  2021-04-30 [1] CRAN (R 4.1.0)
#>  R.methodsS3   1.8.1   2020-08-26 [1] CRAN (R 4.1.0)
#>  R.oo          1.24.0  2020-08-26 [1] CRAN (R 4.1.0)
#>  R.utils       2.11.0  2021-09-26 [1] CRAN (R 4.1.0)
#>  R6            2.5.1   2021-08-19 [1] CRAN (R 4.1.0)
#>  Rcpp          1.0.8   2022-01-13 [1] CRAN (R 4.1.2)
#>  reprex        2.0.1   2021-08-05 [1] CRAN (R 4.1.0)
#>  rlang         1.0.6   2022-09-24 [1] CRAN (R 4.1.2)
#>  rmarkdown     2.12    2022-03-02 [1] CRAN (R 4.1.2)
#>  rstudioapi    0.13    2020-11-12 [1] CRAN (R 4.1.0)
#>  scales        1.2.1   2022-08-20 [1] CRAN (R 4.1.2)
#>  sessioninfo   1.2.2   2021-12-06 [1] CRAN (R 4.1.0)
#>  shiny         1.7.1   2021-10-02 [1] CRAN (R 4.1.0)
#>  stringi       1.7.6   2021-11-29 [1] CRAN (R 4.1.0)
#>  stringr       1.4.0   2019-02-10 [1] CRAN (R 4.1.0)
#>  styler        1.6.2   2021-09-23 [1] CRAN (R 4.1.0)
#>  tibble        3.1.8   2022-07-22 [1] CRAN (R 4.1.2)
#>  tidyselect    1.1.2   2022-02-21 [1] CRAN (R 4.1.2)
#>  utf8          1.2.2   2021-07-24 [1] CRAN (R 4.1.0)
#>  vctrs         0.5.1   2022-11-16 [1] CRAN (R 4.1.2)
#>  withr         2.5.0   2022-03-03 [1] CRAN (R 4.1.2)
#>  xfun          0.29    2021-12-14 [1] CRAN (R 4.1.0)
#>  xml2          1.3.3   2021-11-30 [1] CRAN (R 4.1.0)
#>  xtable        1.8-4   2019-04-21 [1] CRAN (R 4.1.0)
#>  yaml          2.3.5   2022-02-21 [1] CRAN (R 4.1.2)
#> 
#>  [1] /Users/cbaker/Library/R/x86_64/4.1/library
#>  [2] /Library/Frameworks/R.framework/Versions/4.1/Resources/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

## This PR

``` r
library(ggplot2)
library(ggExtra)

p <- ggplot(mtcars, aes(x = mpg, y = wt, colour = factor(am))) + geom_point()

ggMarginal(p, type = "boxplot", groupFill = TRUE)
```

![](https://i.imgur.com/rG5Bujk.png)

``` r

# Not related to this PR: Looks like it's another bug related to rendering 
# ggMarinals. Have to call this or it all gets overwritten on the same "page" 
# on the device.
grid::grid.newpage()

ggMarginal(p, type = "violin", groupFill = TRUE)
```

![](https://i.imgur.com/c2kUnPc.png)

<sup>Created on 2023-01-25 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.1.2 (2021-11-01)
#>  os       macOS Big Sur 10.16
#>  system   x86_64, darwin17.0
#>  ui       X11
#>  language (EN)
#>  collate  en_US.UTF-8
#>  ctype    en_US.UTF-8
#>  tz       America/New_York
#>  date     2023-01-25
#>  pandoc   2.19.2 @ /Applications/RStudio.app/Contents/Resources/app/quarto/bin/tools/ (via rmarkdown)
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version date (UTC) lib source
#>  assertthat    0.2.1   2019-03-21 [1] CRAN (R 4.1.0)
#>  backports     1.4.1   2021-12-13 [1] CRAN (R 4.1.0)
#>  cli           3.6.0   2023-01-09 [1] CRAN (R 4.1.2)
#>  colorspace    2.0-3   2022-02-21 [1] CRAN (R 4.1.2)
#>  curl          4.3.2   2021-06-23 [1] CRAN (R 4.1.0)
#>  DBI           1.1.2   2021-12-20 [1] CRAN (R 4.1.0)
#>  digest        0.6.29  2021-12-01 [1] CRAN (R 4.1.0)
#>  dplyr         1.0.8   2022-02-08 [1] CRAN (R 4.1.2)
#>  ellipsis      0.3.2   2021-04-29 [1] CRAN (R 4.1.0)
#>  evaluate      0.15    2022-02-18 [1] CRAN (R 4.1.2)
#>  fansi         1.0.4   2023-01-22 [1] CRAN (R 4.1.2)
#>  farver        2.1.1   2022-07-06 [1] CRAN (R 4.1.2)
#>  fastmap       1.1.0   2021-01-25 [1] CRAN (R 4.1.0)
#>  fs            1.5.2   2021-12-08 [1] CRAN (R 4.1.0)
#>  generics      0.1.2   2022-01-31 [1] CRAN (R 4.1.2)
#>  ggExtra     * 0.10.0  2023-01-26 [1] local
#>  ggplot2     * 3.4.0   2022-11-04 [1] CRAN (R 4.1.2)
#>  glue          1.6.2   2022-02-24 [1] CRAN (R 4.1.2)
#>  gtable        0.3.1   2022-09-01 [1] CRAN (R 4.1.2)
#>  highr         0.9     2021-04-16 [1] CRAN (R 4.1.0)
#>  htmltools     0.5.2   2021-08-25 [1] CRAN (R 4.1.0)
#>  httpuv        1.6.5   2022-01-05 [1] CRAN (R 4.1.2)
#>  httr          1.4.2   2020-07-20 [1] CRAN (R 4.1.0)
#>  knitr         1.37    2021-12-16 [1] CRAN (R 4.1.0)
#>  labeling      0.4.2   2020-10-20 [1] CRAN (R 4.1.0)
#>  later         1.3.0   2021-08-18 [1] CRAN (R 4.1.0)
#>  lifecycle     1.0.3   2022-10-07 [1] CRAN (R 4.1.2)
#>  magrittr      2.0.3   2022-03-30 [1] CRAN (R 4.1.2)
#>  mime          0.12    2021-09-28 [1] CRAN (R 4.1.0)
#>  miniUI        0.1.1.1 2018-05-18 [1] CRAN (R 4.1.0)
#>  munsell       0.5.0   2018-06-12 [1] CRAN (R 4.1.0)
#>  pillar        1.8.1   2022-08-19 [1] CRAN (R 4.1.2)
#>  pkgconfig     2.0.3   2019-09-22 [1] CRAN (R 4.1.0)
#>  promises      1.2.0.1 2021-02-11 [1] CRAN (R 4.1.0)
#>  purrr         0.3.4   2020-04-17 [1] CRAN (R 4.1.0)
#>  R.cache       0.15.0  2021-04-30 [1] CRAN (R 4.1.0)
#>  R.methodsS3   1.8.1   2020-08-26 [1] CRAN (R 4.1.0)
#>  R.oo          1.24.0  2020-08-26 [1] CRAN (R 4.1.0)
#>  R.utils       2.11.0  2021-09-26 [1] CRAN (R 4.1.0)
#>  R6            2.5.1   2021-08-19 [1] CRAN (R 4.1.0)
#>  Rcpp          1.0.8   2022-01-13 [1] CRAN (R 4.1.2)
#>  reprex        2.0.1   2021-08-05 [1] CRAN (R 4.1.0)
#>  rlang         1.0.6   2022-09-24 [1] CRAN (R 4.1.2)
#>  rmarkdown     2.12    2022-03-02 [1] CRAN (R 4.1.2)
#>  rstudioapi    0.13    2020-11-12 [1] CRAN (R 4.1.0)
#>  scales        1.2.1   2022-08-20 [1] CRAN (R 4.1.2)
#>  sessioninfo   1.2.2   2021-12-06 [1] CRAN (R 4.1.0)
#>  shiny         1.7.1   2021-10-02 [1] CRAN (R 4.1.0)
#>  stringi       1.7.6   2021-11-29 [1] CRAN (R 4.1.0)
#>  stringr       1.4.0   2019-02-10 [1] CRAN (R 4.1.0)
#>  styler        1.6.2   2021-09-23 [1] CRAN (R 4.1.0)
#>  tibble        3.1.8   2022-07-22 [1] CRAN (R 4.1.2)
#>  tidyselect    1.1.2   2022-02-21 [1] CRAN (R 4.1.2)
#>  utf8          1.2.2   2021-07-24 [1] CRAN (R 4.1.0)
#>  vctrs         0.5.1   2022-11-16 [1] CRAN (R 4.1.2)
#>  withr         2.5.0   2022-03-03 [1] CRAN (R 4.1.2)
#>  xfun          0.29    2021-12-14 [1] CRAN (R 4.1.0)
#>  xml2          1.3.3   2021-11-30 [1] CRAN (R 4.1.0)
#>  xtable        1.8-4   2019-04-21 [1] CRAN (R 4.1.0)
#>  yaml          2.3.5   2022-02-21 [1] CRAN (R 4.1.2)
#> 
#>  [1] /Users/cbaker/Library/R/x86_64/4.1/library
#>  [2] /Library/Frameworks/R.framework/Versions/4.1/Resources/library
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>

Not a great example I know; It's kinda hard to tell with the boxplots what the difference is, and with the violins, it almost looks like the issue is still persisting. I believe the violins are still correct, though, as, as the widths of a given violin will be a function of the underlying distribution.

